### PR TITLE
Allow for Role Names to have Uppercase and Numbers

### DIFF
--- a/aws_assume_role_helper/__main__.py
+++ b/aws_assume_role_helper/__main__.py
@@ -51,7 +51,7 @@ def parse_arguments():
 
 
 def iam_role_type(role_arn):
-    regex = r'^arn:aws:iam::[0-9]{12}:role\/[a-z_+=,.@-]*$'
+    regex = r'^arn:aws:iam::[0-9]{12}:role\/[a-zA-Z0-9_+=,.@-]*$'
 
     if not re.match(regex, role_arn):
         raise "Not a valid IAM ARN"


### PR DESCRIPTION
Roles automatically created by Amplify/CF can have uppercase and numbers. 